### PR TITLE
Make onboard write to global ~/.claude/CLAUDE.md

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ VAULT MANAGEMENT
   psst init                     Create local vault (.psst/)
   psst init --global            Create global vault (~/.psst/)
   psst init --env <name>        Create vault for specific environment
-  psst onboard                  Add psst instructions to CLAUDE.md/AGENTS.md
+  psst onboard                  Add psst instructions to ~/.claude/CLAUDE.md
   psst lock                     Lock vault (encrypt at rest)
   psst unlock                   Unlock vault
   psst list envs                List available environments


### PR DESCRIPTION
## Summary
- `psst onboard` now writes to `~/.claude/CLAUDE.md` instead of project-level CLAUDE.md/AGENTS.md
- Instructions updated to compact XML format matching the manually-written global config
- Includes the shell arg-splitting gotcha (`psst run` workaround for pipes/semicolons)

Closes #25

## Test plan
- [x] `bun test` — 186 tests pass
- [x] Manual: verified onboard writes to correct path and is idempotent