### PR TITLE
fix: read /proc/self/environ so PSST_PASSWORD survives ptrace-based sandbox injection

### DIFF
--- a/src/vault/native-env.ts
+++ b/src/vault/native-env.ts
@@ -1,0 +1,46 @@
+/**
+ * native-env.ts — reads env vars via /proc/self/environ.
+ *
+ * Bun initialises process.env from envp[] very early in its startup
+ * sequence. Sandbox supervisors (e.g. nono in ptrace/supervised mode)
+ * may inject credentials into the process environment after exec, which
+ * means they appear in the kernel's live view at /proc/self/environ but
+ * are absent from process.env. Reading /proc/self/environ at call-time
+ * captures the post-injection state, making those vars visible.
+ *
+ * Linux-only — on other platforms getenvNative always returns null.
+ */
+
+import { readFileSync } from "node:fs";
+
+let _env: Map<string, string> | null | undefined = undefined;
+
+function loadProcEnv(): Map<string, string> | null {
+  if (process.platform !== "linux") return null;
+  try {
+    const raw = readFileSync("/proc/self/environ", "utf-8");
+    const map = new Map<string, string>();
+    for (const entry of raw.split("\0")) {
+      const eq = entry.indexOf("=");
+      if (eq !== -1) map.set(entry.slice(0, eq), entry.slice(eq + 1));
+    }
+    if (map.get("PSST_DEBUG") === "1" || process.env.PSST_DEBUG === "1") {
+      process.stderr.write(
+        `[psst debug] native-env: /proc/self/environ has ${map.size} entries,` +
+          ` PSST_PASSWORD=${map.has("PSST_PASSWORD") ? "present" : "absent"}\n`,
+      );
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return the value of an environment variable from /proc/self/environ,
+ * or null if unset or the file is unreadable.
+ */
+export function getenvNative(name: string): string | null {
+  if (_env === undefined) _env = loadProcEnv();
+  return _env?.get(name) ?? null;
+}

--- a/src/vault/sqlite-backend.ts
+++ b/src/vault/sqlite-backend.ts
@@ -8,6 +8,7 @@
  */
 
 import { join } from "node:path";
+import { getenvNative } from "./native-env.js";
 import type {
   SecretHistoryRecord,
   SecretMetaRecord,
@@ -91,14 +92,27 @@ export class SqliteBackend implements VaultBackend {
   async unlock(): Promise<boolean> {
     if (this.key) return true;
 
-    const keychainResult = await getKey();
-    if (keychainResult.success && keychainResult.key) {
-      this.key = keyToBuffer(keychainResult.key);
+    const password = process.env.PSST_PASSWORD ?? getenvNative("PSST_PASSWORD");
+    const debug =
+      (process.env.PSST_DEBUG ?? getenvNative("PSST_DEBUG")) === "1";
+    if (debug) {
+      process.stderr.write(
+        `[psst debug] unlock: PSST_PASSWORD=${password ? `set(len=${password.length})` : "unset"}\n`,
+      );
+    }
+    if (password) {
+      this.key = keyToBuffer(password);
       return true;
     }
 
-    if (process.env.PSST_PASSWORD) {
-      this.key = keyToBuffer(process.env.PSST_PASSWORD);
+    const keychainResult = await getKey();
+    if (debug) {
+      process.stderr.write(
+        `[psst debug] unlock: keychain success=${keychainResult.success} error=${keychainResult.error ?? "none"}\n`,
+      );
+    }
+    if (keychainResult.success && keychainResult.key) {
+      this.key = keyToBuffer(keychainResult.key);
       return true;
     }
 


### PR DESCRIPTION
**Problem**

`psst unlock` fails with "Failed to unlock vault" when `PSST_PASSWORD` is injected by a ptrace-based sandbox supervisor (e.g. [nono](https://nono.run) in supervised mode), even though the variable is present in the process environment.

The root cause is a timing gap between Bun and ptrace injection. Bun snapshots `process.env` from `envp[]` very early in its startup sequence — before a ptrace supervisor has had a chance to write into the process environment. The injected variable is present in the kernel's live view (`/proc/self/environ`) but absent from `process.env`.

This affects any runtime that snapshots `envp[]` at startup (Bun, Go, JVM). It does not affect Node.js or bash, which call through glibc's `getenv()` and see the live `environ` pointer.

**Reproduction**

```bash
# 1. create a demo directory and init a vault
mkdir psst-demo && cd psst-demo
PSST_PASSWORD=demo-password-1234 psst init

# 2. add an example secret
echo "my-secret-value" | PSST_PASSWORD=demo-password-1234 psst set --stdin EXAMPLE_SECRET

# 3. verify it works normally outside the sandbox
PSST_PASSWORD=demo-password-1234 psst list
# ● EXAMPLE_SECRET
# 1 secret(s)

# 4. store the password where nono can inject it (1Password shown; secret-tool works too)
#    op item create --title psst-demo --vault Personal password=demo-password-1234

# 5. run inside the sandbox — nono injects PSST_PASSWORD via ptrace after execve()
nono run --env-credential-map 'op://Personal/psst-demo/password' PSST_PASSWORD --allow-cwd -- psst list
```

Before fix:
```
✗ Failed to unlock vault
```

After fix (with `PSST_DEBUG=1`):
```
[psst debug] native-env: /proc/self/environ has 86 entries, PSST_PASSWORD=present
[psst debug] unlock: PSST_PASSWORD=set(len=20)

Secrets

● EXAMPLE_SECRET

1 secret(s)
```

**Changes**

- Add `src/vault/native-env.ts`: reads `/proc/self/environ` at call-time and exposes `getenvNative(name)`. Linux-only; returns `null` on other platforms. Result is cached after first read.
- In `SqliteBackend.unlock()`: fall back to `getenvNative()` when `process.env.PSST_PASSWORD` is unset, so injected credentials are found even if Bun missed them at startup.
- Fix unlock priority order: env var (both sources) → keychain. Previously keychain was checked first, which could fail or block inside a sandbox before the env var fallback was tried.
- Add `PSST_DEBUG=1` logging to the unlock path (itself read via both sources) to make this class of failure diagnosable without rebuilding.